### PR TITLE
Pass single device ID as string

### DIFF
--- a/CHANGELOG.rst
+++ b/CHANGELOG.rst
@@ -7,6 +7,7 @@ openeew uses `Semantic Versioning <http://semver.org/>`_
 Unreleased
 =============
 - Allow to get number of sample points in a record using general axis labels
+- Pass single device ID as string when retrieving records
 
 Version 0.5.0
 =============

--- a/README.rst
+++ b/README.rst
@@ -78,6 +78,14 @@ It is also possible to specify a list of device IDs::
     ['001', '008'] # optional list of device IDs
     )
     
+A single device ID can be passed as a string::
+
+  records = data_client.get_filtered_records(
+    start_date_utc,
+    end_date_utc,
+    '001' # optional single device ID
+    )
+
 We can change the country if we want. So if we now want to look at Chile data::
 
   data_client.country_code = 'cl'

--- a/src/openeew/data/aws.py
+++ b/src/openeew/data/aws.py
@@ -191,6 +191,19 @@ class AwsDataClient(object):
         if end_dt < start_dt:
             raise ValueError('end date should not be earlier than start date')
 
+        if device_ids is None:
+            # Get list of all available devices
+            _device_ids = self._get_device_ids_from_records()
+        elif isinstance(device_ids, str):
+            # Add single device to list
+            _device_ids = [device_ids]
+        elif isinstance(device_ids, list):
+            # Use list directly
+            _device_ids = device_ids
+        else:
+            raise ValueError('device_ids, if specified, should be either '
+                             'a string or a list')
+
         # A simple lower bound for keys to download (without making
         # assumptions on num minutes contained per file) is given by
         # the hour corresponding to the start date
@@ -213,7 +226,7 @@ class AwsDataClient(object):
         # Initialize empty list to store the keys to download
         keys_to_download = []
         paginator = self._s3_client.get_paginator('list_objects_v2')
-        _device_ids = device_ids or self._get_device_ids_from_records()
+
         for d in _device_ids:
 
             device_prefix = self._get_records_key_device_prefix(d)
@@ -324,8 +337,8 @@ class AwsDataClient(object):
             equal to or less than end_date_utc will be returned.
         :type end_date_utc: str
 
-        :param device_ids: List of device IDs that should be returned.
-        :type device_ids: list[str]
+        :param device_ids: Device IDs that should be returned.
+        :type device_ids: Union[str, list[str]]
 
         :return: A list of records, where each record is a dict
             obtained from the stored JSON value. For details about the


### PR DESCRIPTION
This removes the need to pass a single device ID as a list.